### PR TITLE
add ios code for controlling and getting brightness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+.packages

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/ios/Classes/SwiftFlutterScreenWakePlugin.swift
+++ b/ios/Classes/SwiftFlutterScreenWakePlugin.swift
@@ -16,7 +16,15 @@ public class SwiftFlutterScreenWakePlugin: NSObject, FlutterPlugin {
             if let args = call.arguments as? Dictionary<String, Any>,
                let brightness = args["brightness"] as? Double {
                 UIScreen.main.brightness = CGFloat(brightness)
-                result(nil)
+                result(nil);
+            }
+        case "isKeptOn":
+            result(UIApplication.shared.isIdleTimerDisabled);
+        case "keepOn":
+            if let args = call.arguments as? Dictionary<String, Any>,
+               let keepOn = args["on"] as? Bool {
+                UIApplication.shared.isIdleTimerDisabled = keepOn
+                result(nil);
             }
         default:
             result(FlutterMethodNotImplemented);

--- a/ios/Classes/SwiftFlutterScreenWakePlugin.swift
+++ b/ios/Classes/SwiftFlutterScreenWakePlugin.swift
@@ -9,6 +9,17 @@ public class SwiftFlutterScreenWakePlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    result("iOS " + UIDevice.current.systemVersion)
+    switch call.method {
+        case "brightness":
+            result(UIScreen.main.brightness);
+        case "setBrightness":
+            if let args = call.arguments as? Dictionary<String, Any>,
+               let brightness = args["brightness"] as? Double {
+                UIScreen.main.brightness = CGFloat(brightness)
+                result(nil)
+            }
+        default:
+            result(FlutterMethodNotImplemented);
+    }
   }
 }


### PR DESCRIPTION
When running FlutterScreenWake.brightness on iOS it was throwing an exception saying it got a string instead of double, so I looked into it quickly and added the missing code for this.

I might also add the screen wake stuff later if you are interested in that.

Edit: 
Turns out screen wake control is also really easy to implement so I added it as well. 
Tested all of this with the example app on my iPhone 7.